### PR TITLE
feat: replace `downloader` with `reqwest`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,10 +214,12 @@ dependencies = [
  "acvm",
  "ark-std",
  "dirs",
- "downloader",
+ "futures-util",
  "halo2_proofs",
  "indicatif",
  "rand",
+ "reqwest",
+ "tokio",
 ]
 
 [[package]]
@@ -491,19 +493,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "downloader"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05213e96f184578b5f70105d4d0a644a168e99e12d7bea0b200c15d67b5c182"
-dependencies = [
- "futures",
- "rand",
- "reqwest",
- "thiserror",
- "tokio",
-]
-
-[[package]]
 name = "ecdsa"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,28 +602,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futures"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -642,17 +615,6 @@ name = "futures-core"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -689,7 +651,6 @@ version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -929,14 +890,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.15.0"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
+checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
 dependencies = [
  "console",
- "lazy_static",
  "number_prefix",
- "regex",
+ "portable-atomic",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1086,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "number_prefix"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -1149,6 +1110,12 @@ checksum = "b4839a901843f3942576e65857f0ebf2e190ef7024d3c62a94099ba3f819ad1d"
 dependencies = [
  "der",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
 
 [[package]]
 name = "ppv-lite86"
@@ -1265,21 +1232,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
-dependencies = [
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
 name = "reqwest"
 version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,10 +1261,12 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
  "winreg",
@@ -1596,7 +1550,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "socket2",
  "windows-sys 0.45.0",
@@ -1814,6 +1767,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+
+[[package]]
+name = "wasm-streams"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ halo2_proofs_axiom = { git = "https://github.com/axiom-crypto/halo2.git", tag = 
 rand = "0.8"
 ark-std = "0.4"
 dirs = "3.0"
-downloader = { version = "0.2.7", default-features = false, features = [
-    "rustls-tls",
-] }
-indicatif = "0.15.0"
+reqwest = { version = "0.11.16", default-features = false, features = ["stream", "rustls-tls"] }
+tokio = "1.0"
+futures-util = "0.3.14"
+indicatif = "0.17.3"

--- a/src/aztec_crs.rs
+++ b/src/aztec_crs.rs
@@ -1,0 +1,129 @@
+use std::{env, fs::File, io::Write, path::PathBuf};
+
+use futures_util::StreamExt;
+
+const G1_START: usize = 28;
+const G2_START: usize = 28 + (5_040_000 * 64);
+const G2_END: usize = G2_START + 128 - 1;
+
+const AZTEC_BACKEND_IDENTIFIER: &str = "acvm-backend-barretenberg";
+const TRANSCRIPT_NAME: &str = "transcript00.dat";
+const TRANSCRIPT_URL: &str =
+    "http://aztec-ignition.s3.amazonaws.com/MAIN%20IGNITION/sealed/transcript00.dat";
+
+fn transcript_location() -> PathBuf {
+    match env::var("BARRETENBERG_TRANSCRIPT") {
+        Ok(dir) => PathBuf::from(dir),
+        Err(_) => dirs::home_dir()
+            .unwrap()
+            .join(".nargo")
+            .join("backends")
+            .join(AZTEC_BACKEND_IDENTIFIER)
+            .join(TRANSCRIPT_NAME),
+    }
+}
+
+pub(crate) fn get_aztec_crs(points_needed: u32) -> (Vec<u8>, Vec<u8>) {
+    let g1_end = G1_START + ((points_needed as usize - 1) * 64) - 1;
+    // If the CRS does not exist, then download it from S3
+    if !transcript_location().exists() {
+        download_crs(transcript_location()).unwrap();
+    }
+
+    // Read CRS, if it's incomplete, download it
+    let mut crs = read_crs(transcript_location());
+    if crs.len() < G2_END + 1 {
+        download_crs(transcript_location()).unwrap();
+        crs = read_crs(transcript_location());
+    }
+
+    let g1_data = crs[G1_START..=g1_end].to_vec();
+    let g2_data = crs[G2_START..=G2_END].to_vec();
+
+    (g1_data, g2_data)
+}
+
+fn read_crs(path: PathBuf) -> Vec<u8> {
+    match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            assert!(
+                e.kind() != std::io::ErrorKind::PermissionDenied,
+                "please run again with appropriate permissions."
+            );
+            panic!(
+                "Could not find transcript at location {}.\n Starting Download",
+                path.display()
+            );
+        }
+    }
+}
+
+// XXX: Below is the logic to download the CRS if it is not already present
+
+fn download_crs(path_to_transcript: PathBuf) -> Result<(), String> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(download_crs_async(path_to_transcript))
+}
+
+async fn download_crs_async(path_to_transcript: PathBuf) -> Result<(), String> {
+    // Remove old crs
+    if path_to_transcript.exists() {
+        let _ = std::fs::remove_file(path_to_transcript.as_path());
+    }
+
+    // Pop off the transcript component to get just the directory
+    let transcript_dir = path_to_transcript
+        .parent()
+        .expect("transcript file should have parent");
+
+    if !transcript_dir.exists() {
+        std::fs::create_dir_all(transcript_dir).unwrap();
+    }
+
+    let res = reqwest::get(TRANSCRIPT_URL)
+        .await
+        .map_err(|err| format!("Failed to GET from '{}' ({})", TRANSCRIPT_URL, err))?;
+    let total_size = res.content_length().ok_or(format!(
+        "Failed to get content length from '{}'",
+        TRANSCRIPT_URL
+    ))?;
+
+    // Indicatif setup
+    use indicatif::{HumanBytes, ProgressBar, ProgressStyle};
+    let pb = ProgressBar::new(total_size).with_style(
+        ProgressStyle::default_bar()
+            .template("[{elapsed_precise}] {bar:40.cyan/blue} {bytes:>7}/{total_bytes:7} {msg}")
+            .unwrap()
+            .progress_chars("##-"),
+    );
+
+    // download chunks
+    let mut file = File::create(path_to_transcript.clone()).map_err(|err| {
+        format!(
+            "Failed to create file '{}' ({})",
+            path_to_transcript.display(),
+            err
+        )
+    })?;
+    let mut stream = res.bytes_stream();
+
+    println!(
+        "\nDownloading the Ignite SRS ({})\n",
+        HumanBytes(total_size)
+    );
+    while let Some(item) = stream.next().await {
+        let chunk = item.map_err(|_| "Error while downloading file".to_string())?;
+        file.write_all(&chunk)
+            .map_err(|_| "Error while writing to file".to_string())?;
+        pb.inc(chunk.len() as u64);
+    }
+    pb.finish_with_message("Downloaded the SRS successfully!\n");
+
+    println!("SRS is located at: {:?}", &path_to_transcript);
+
+    Ok(())
+}

--- a/src/halo2_params.rs
+++ b/src/halo2_params.rs
@@ -1,5 +1,4 @@
-use std::{env, path::PathBuf};
-
+use crate::aztec_crs::get_aztec_crs;
 use ark_std::log2;
 use halo2_proofs_axiom::{
     arithmetic::g_to_lagrange,
@@ -12,54 +11,9 @@ use halo2_proofs_axiom::{
     poly::kzg::commitment::ParamsKZG,
 };
 
-const G1_START: usize = 28;
-const G2_START: usize = 28 + (5_040_000 * 64);
-const G2_END: usize = G2_START + 128 - 1;
-
-fn transcript_location() -> PathBuf {
-    match env::var("BARRETENBERG_TRANSCRIPT") {
-        Ok(dir) => PathBuf::from(dir),
-        Err(_) => dirs::home_dir()
-            .unwrap()
-            .join("noir_cache")
-            .join("ignition")
-            .join("transcript00.dat"),
-    }
-}
-
-fn read_crs(path: PathBuf) -> Vec<u8> {
-    match std::fs::read(&path) {
-        Ok(bytes) => bytes,
-        Err(e) => {
-            assert!(
-                e.kind() != std::io::ErrorKind::PermissionDenied,
-                "please run again with appropriate permissions."
-            );
-            panic!(
-                "Could not find file transcript00.dat at location {}.\n Starting Download",
-                path.display()
-            );
-        }
-    }
-}
-
 pub(crate) fn constuct_halo2_params_from_aztec_crs(num_points: u32) -> ParamsKZG<Bn256> {
     let points_needed = pow2ceil(num_points);
-    let g1_end = G1_START + ((points_needed as usize - 1) * 64) - 1;
-    // If the CRS does not exist, then download it from S3
-    if !transcript_location().exists() {
-        download_crs(transcript_location());
-    }
-
-    // Read CRS, if it's incomplete, download it
-    let mut crs = read_crs(transcript_location());
-    if crs.len() < G2_END + 1 {
-        download_crs(transcript_location());
-        crs = read_crs(transcript_location());
-    }
-
-    let g1_data = crs[G1_START..=g1_end].to_vec();
-    let g2_data = crs[G2_START..=G2_END].to_vec();
+    let (g1_data, g2_data) = get_aztec_crs(points_needed);
 
     let k = log2(points_needed as usize);
     let n = points_needed as u64;
@@ -83,93 +37,6 @@ pub(crate) fn constuct_halo2_params_from_aztec_crs(num_points: u32) -> ParamsKZG
         g_lagrange,
         g2,
         s_g2,
-    }
-}
-
-pub fn download_crs(mut path_to_transcript: PathBuf) {
-    // Remove old crs
-    if path_to_transcript.exists() {
-        let _ = std::fs::remove_file(path_to_transcript.as_path());
-    }
-    // Pop off the transcript component to get just the directory
-    path_to_transcript.pop();
-
-    if !path_to_transcript.exists() {
-        std::fs::create_dir_all(&path_to_transcript).unwrap();
-    }
-
-    let url = "http://aztec-ignition.s3.amazonaws.com/MAIN%20IGNITION/sealed/transcript00.dat";
-    use downloader::Downloader;
-    let mut downloader = Downloader::builder()
-        .download_folder(path_to_transcript.as_path())
-        .build()
-        .unwrap();
-
-    let dl = downloader::Download::new(url);
-    let dl = dl.progress(SimpleReporter::create());
-    let result = downloader.download(&[dl]).unwrap();
-
-    for r in result {
-        match r {
-            Err(e) => println!("Error: {e}"),
-            Ok(s) => println!("\nSRS is located at : {:?}", &s.file_name),
-        };
-    }
-}
-
-// Taken from https://github.com/hunger/downloader/blob/main/examples/download.rs
-struct SimpleReporterPrivate {
-    started: std::time::Instant,
-    progress_bar: indicatif::ProgressBar,
-}
-struct SimpleReporter {
-    private: std::sync::Mutex<Option<SimpleReporterPrivate>>,
-}
-
-impl SimpleReporter {
-    fn create() -> std::sync::Arc<Self> {
-        std::sync::Arc::new(Self {
-            private: std::sync::Mutex::new(None),
-        })
-    }
-}
-
-impl downloader::progress::Reporter for SimpleReporter {
-    fn setup(&self, max_progress: Option<u64>, _message: &str) {
-        let bar = indicatif::ProgressBar::new(max_progress.unwrap());
-        bar.set_style(
-            indicatif::ProgressStyle::default_bar()
-                .template("[{elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} {msg}")
-                .progress_chars("##-"),
-        );
-
-        let private = SimpleReporterPrivate {
-            started: std::time::Instant::now(),
-            progress_bar: bar,
-        };
-        println!("\nDownloading the Ignite SRS (340MB)\n");
-
-        let mut guard = self.private.lock().unwrap();
-        *guard = Some(private);
-    }
-
-    fn progress(&self, current: u64) {
-        if let Some(p) = self.private.lock().unwrap().as_mut() {
-            p.progress_bar.set_position(current);
-        }
-    }
-
-    fn set_message(&self, _message: &str) {}
-
-    fn done(&self) {
-        let mut guard = self.private.lock().unwrap();
-        let p = guard.as_mut().unwrap();
-        p.progress_bar.finish();
-        println!("Downloaded the SRS successfully!");
-        println!(
-            "Time Elapsed: {}",
-            indicatif::HumanDuration(p.started.elapsed())
-        );
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod acvm_interop;
 pub use acvm_interop::Halo2;
 
+mod aztec_crs;
 pub mod circuit_translator;
 mod halo2_params;
 pub mod halo2_plonk_api;


### PR DESCRIPTION
Pulling over a refactoring from https://github.com/noir-lang/aztec_backend/pull/114.

I've separated the handling of the aztec CRS into a separate module so that halo2 code only relies on having *something* which provides g1 and g2 data.

btw, you're relying on the old transcript whereas aztec_backend is moving to the monomial transcript so you're going to end up with errors on this as each backend is writing to the same path.