### PR TITLE
Adding table readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,39 +72,25 @@ nargo codegen-verifier
 - [x] [halo2-pse](https://github.com/privacy-scaling-explorations/halo2)
 - [x] [halo2-axiom](https://github.com/axiom-crypto/halo2-lib)
 
-### halo2-pse features
+### Halo2 Features
 
-- [x] arithmetic gates
-- [x] range proofs
-- [x] and gates
+| Features | halo2-pse | halo2-axiom |
+| --- | --- | --- |
+| arithmetic gates | ✔️ | ✔️ |
+| range proofs | ✔️ | ✔️ |
+| and gates | ✔️ | ✔️ |
+| xor |  |  |
+| sha256 |  |  |
+| blake2s |  |  |
+| schnorr_verify |  |  |
+| pedersen |  |  |
+| hash_to_field |  |  |
+| ecdsa_secp256k1 |  |  |
+| fixed_base_scalar_mul |  |  |
+| keccak256 |  |  |
+| keccak256_variable_length |  |  |
 
-- [ ] xor
-- [ ] sha256 
-- [ ] blake2s 
-- [ ] schnorr_verify
-- [ ] pedersen
-- [ ] hash_to_field
-- [ ] ecdsa_secp256k1
-- [ ] fixed_base_scalar_mul
-- [ ] keccak256
-- [ ] keccak256_variable_length 
-
-### halo2-axiom features
-
-- [x] arithmetic gates
-- [x] range proofs
-- [x] and gates
-
-- [ ] xor
-- [ ] sha256 
-- [ ] blake2s 
-- [ ] schnorr_verify
-- [ ] pedersen
-- [ ] hash_to_field
-- [ ] ecdsa_secp256k1
-- [ ] fixed_base_scalar_mul
-- [ ] keccak256
-- [ ] keccak256_variable_length 
+✔️ indicates that the feature is present. The first three features are present in both halo2-pse and halo2-axiom.
 
 ## License
 


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

Making readme shorter by removing redundant text, and replacing it instead with a table.

Resolves  https://github.com/Ethan-000/halo2_backend/issues/49#issue-2019335316

## Summary\*

Replaces the long text in the feature section with a table. 
Example as such: 
features | halo2-pse | halo2-axiom
-- | -- | --
feature X | supported | supported
feature Y | supported | not supported
feature Z | not supported | supported

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
